### PR TITLE
HOPSWORKS-745: Make sparkSQL compatible with HopsHive

### DIFF
--- a/Karamelfile
+++ b/Karamelfile
@@ -9,6 +9,7 @@ dependencies:
       - hops::dn
   - recipe: hadoop_spark::yarn
     global:
+      - hadoop_spark::install
       - hops::dn
   - recipe: hadoop_spark::worker
     global:

--- a/Karamelfile
+++ b/Karamelfile
@@ -9,7 +9,6 @@ dependencies:
       - hops::dn
   - recipe: hadoop_spark::yarn
     global:
-      - hadoop_spark::install
       - hops::dn
   - recipe: hadoop_spark::worker
     global:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -91,3 +91,8 @@ default['hopsmonitor']['default']['private_ips']                  = ['10.0.2.15'
 default['hopslog']['default']['private_ips']                      = ['10.0.2.15']
 default['hopsworks']['domain_truststore_path']                    = "#{node['hopsworks']['domain_truststore_path']}"
 default['hopsworks']['domain_truststore']                         = "#{node['hopsworks']['domain_truststore']}"
+
+# Hive config
+default['hive2']['metastore']['port']                             = "9083"
+default['hive2']['hopsfs_dir']                                    = "/apps/hive"
+default['hive2']['scratch_dir']                                   = "/tmp/hive"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 include_attribute "kagent"
 include_attribute "hops"
 include_attribute "hopsmonitor"
+include_attribute "hive2"
 
 default['hadoop_spark']['user']                                 = node['install']['user'].empty? ? "spark" : node['install']['user']
 default['hadoop_spark']['group']                                = node['install']['user'].empty? ? node['hops']['group'] : node['install']['user']
@@ -91,8 +92,3 @@ default['hopsmonitor']['default']['private_ips']                  = ['10.0.2.15'
 default['hopslog']['default']['private_ips']                      = ['10.0.2.15']
 default['hopsworks']['domain_truststore_path']                    = "#{node['hopsworks']['domain_truststore_path']}"
 default['hopsworks']['domain_truststore']                         = "#{node['hopsworks']['domain_truststore']}"
-
-# Hive config
-default['hive2']['metastore']['port']                             = "9083"
-default['hive2']['hopsfs_dir']                                    = "/apps/hive"
-default['hive2']['scratch_dir']                                   = "/tmp/hive"

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,7 @@ depends          "java"
 depends          "hops"
 depends          "magic_shell"
 depends          "hopsmonitor"
+depends          'hive2'
 
 recipe           "install", "Installs Spark binaries"
 #link:<a target='_blank' href='http://%host%:8080/'>Launch the WebUI for the Spark Master</a>

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -171,3 +171,22 @@ end
 magic_shell_environment 'SPARK_HOME' do
   value node['hadoop_spark']['base_dir']
 end
+
+nn_endpoint = private_recipe_ip("hops", "nn") + ":#{node['hops']['nn']['port']}"
+begin
+  metastore_ip = private_recipe_ip("hive2", "metastore")
+rescue
+  metastore_ip = private_recipe_ip("hive2", "default")
+  Chef::Log.warn "Using default ip for metastore (metastore service not defined in cluster definition (yml) file."
+end
+
+template "#{node['hadoop_spark']['home']}/conf/hive-site.xml" do
+  source "hive-site.xml.erb"
+  owner node['hadoop_spark']['user']
+  group node['hadoop_spark']['group']
+  mode 0655
+  variables({
+                :nn_endpoint => nn_endpoint,
+                :metastore_ip => metastore_ip
+            })
+end

--- a/recipes/yarn.rb
+++ b/recipes/yarn.rb
@@ -221,6 +221,15 @@ if (File.exist?("#{node['kagent']['certs_dir']}/cacerts.jks"))
     dest "/user/#{node['hadoop_spark']['user']}/cacerts.jks"
   end
 
+  #copy hive-site.xml to hdfs so that node-managers can download it to containers for running hive-jobs/notebooks
+  hops_hdfs_directory "#{node['hadoop_spark']['home']}/conf/hive-site.xml" do
+    action :replace_as_superuser
+    owner node['hadoop_spark']['user']
+    group node['hops']['group']
+    mode "1775"
+    dest "/user/#{node['hadoop_spark']['user']}/hive-site.xml"
+  end
+
   bash 'cleanup_truststore' do
     user "root"
     code <<-EOH

--- a/templates/default/hive-site.xml.erb
+++ b/templates/default/hive-site.xml.erb
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Hive configuration for SparkSQL
+   -->
+<configuration>
+  <property>
+    <name>hive.metastore.warehouse.dir</name>
+    <value>hdfs://<%= @nn_endpoint %><%= node['hive2']['hopsfs_dir'] %>/warehouse</value>
+    <description>location of default database for the warehouse</description>
+  </property>
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>thrift://<%= @metastore_ip %>:<%= node['hive2']['metastore']['port'] %></value>
+    <description>Thrift URI for the remote metastore. Used by metastore client to connect to remote metastore.</description>
+  </property>
+</configuration>


### PR DESCRIPTION
This is a combination of 2 commits.
The first commit's message is:

add hive-site.xml to spark conf for sparkSQL

This is the 2nd commit message:

materialize hive-site.xml to HDFS to be accessible in spark.yarn.dist.files