### PR TITLE
[HOPSWORKS-1762] Add support for Spark-Tfrecord

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -119,6 +119,7 @@ default['hadoop_spark']['hopsexamples_featurestore_util_py']['url']   = "#{node[
 #
 default['hadoop_spark']['spark_avro_version']                            = "2.11-2.4.0"
 default['hadoop_spark']['tf_spark_connector_version']                    = "2.11-1.12.0"
+default['hadoop_spark']['spark_tfrecord_version']                        = "2.11-0.1.1"
 default['hadoop_spark']['mysql_driver']                                  = "#{node['download_url']}/mysql-connector-java-5.1.29-bin.jar"
 
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -106,6 +106,10 @@ attribute "hadoop_spark/tf_spark_connector_version",
           :description => "the version of the tf-spark-connector .jar",
           :type => "string"
 
+attribute "hadoop_spark/spark_tfrecord_version",
+          :description => "the version of the spark-tfrecord library .jar",
+          :type => "string"
+
 attribute "hadoop_spark/hopsutil_version",
           :description => "the version of the hops-library .jar",
           :type => "string"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -132,7 +132,7 @@ sql_dep = [
   "parquet-format-#{node['hadoop_spark']['parquet_format_version']}.jar",
   "snappy-0.4.jar",
   "spark-avro_#{node['hadoop_spark']['spark_avro_version']}.jar",
-  "spark-tensorflow-connector_#{node['hadoop_spark']['tf_spark_connector_version']}.jar",
+#  "spark-tensorflow-connector_#{node['hadoop_spark']['tf_spark_connector_version']}.jar",
   "spark-tfrecord_#{node['hadoop_spark']['spark_tfrecord_version']}.jar",  
   "spark-avro_#{node['hadoop_spark']['databricks_spark_avro_version']}.jar",
   "delta-core_#{node['hadoop_spark']['databricks_delta_version']}.jar"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -132,7 +132,7 @@ sql_dep = [
   "parquet-format-#{node['hadoop_spark']['parquet_format_version']}.jar",
   "snappy-0.4.jar",
   "spark-avro_#{node['hadoop_spark']['spark_avro_version']}.jar",
-#  "spark-tensorflow-connector_#{node['hadoop_spark']['tf_spark_connector_version']}.jar",
+  "spark-tensorflow-connector_#{node['hadoop_spark']['tf_spark_connector_version']}.jar",
   "spark-tfrecord_#{node['hadoop_spark']['spark_tfrecord_version']}.jar",  
   "spark-avro_#{node['hadoop_spark']['databricks_spark_avro_version']}.jar",
   "delta-core_#{node['hadoop_spark']['databricks_delta_version']}.jar"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -133,6 +133,7 @@ sql_dep = [
   "snappy-0.4.jar",
   "spark-avro_#{node['hadoop_spark']['spark_avro_version']}.jar",
   "spark-tensorflow-connector_#{node['hadoop_spark']['tf_spark_connector_version']}.jar",
+  "spark-tfrecord_#{node['hadoop_spark']['spark_tfrecord_version']}.jar",  
   "spark-avro_#{node['hadoop_spark']['databricks_spark_avro_version']}.jar",
   "delta-core_#{node['hadoop_spark']['databricks_delta_version']}.jar"
 ]


### PR DESCRIPTION
Keep both connectors. supersedes and closes #98 .

https://logicalclocks.atlassian.net/browse/HOPSWORKS-1762