### PR TITLE
[HOPSWORKS-2869] Improve Spark/PySpark logging

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -187,20 +187,6 @@ template"#{node['hadoop_spark']['conf_dir']}/log4j.properties" do
   mode 0650
 end
 
-template"#{node['hadoop_spark']['conf_dir']}/yarnclient-driver-log4j.properties" do
-  source "yarnclient-driver-log4j.properties.erb"
-  owner node['hadoop_spark']['user']
-  group node['hops']['group']
-  mode 0655
-end
-
-template"#{node['hadoop_spark']['conf_dir']}/executor-log4j.properties" do
-  source "executor-log4j.properties.erb"
-  owner node['hadoop_spark']['user']
-  group node['hops']['group']
-  mode 0655
-end
-
 template"#{node['hadoop_spark']['home']}/conf/spark-env.sh" do
   source "spark-env.sh.erb"
   owner node['hadoop_spark']['user']

--- a/templates/default/app.log4j.properties.erb
+++ b/templates/default/app.log4j.properties.erb
@@ -1,9 +1,22 @@
-# Set everything to be logged to the console
-log4j.rootLogger=INFO,console
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %p ${hopsworks.logstash.job.info} %c{1}: %m%n
 
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %p ${hopsworks.logstash.job.info} %c{1}: %m%n
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %p ${hopsworks.logstash.job.info} %c{1}: %m%n
 
 # Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty=WARN,stderr
+log4j.additivity.org.eclipse.jetty=false
+
+log4j.logger.org.apache=INFO,stderr
+log4j.additivity.org.apache=false
+
+log4j.logger.org.sparkproject=INFO,stderr
+log4j.additivity.org.sparkproject=false
+
+# Set everything to be logged to the stdout
+log4j.rootLogger=INFO,stdout

--- a/templates/default/executor-log4j.properties.erb
+++ b/templates/default/executor-log4j.properties.erb
@@ -1,9 +1,0 @@
-# Set everything to be logged to the console
-log4j.rootCategory=INFO, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-
-# Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.eclipse.jetty=WARN
-

--- a/templates/default/slaves.erb
+++ b/templates/default/slaves.erb
@@ -1,3 +1,0 @@
-<% for slave in node['hadoop_spark']['worker']['private_ips'] -%>
-<%= slave %>
-<% end -%>

--- a/templates/default/yarnclient-driver-log4j.properties.erb
+++ b/templates/default/yarnclient-driver-log4j.properties.erb
@@ -1,8 +1,0 @@
-# Set everything to be logged to the console
-log4j.rootCategory=INFO, console
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
-
-# Ignore messages below warning level from Jetty, because it's a bit verbose
-log4j.logger.org.eclipse.jetty=WARN


### PR DESCRIPTION
Redirect all org.apache logs to stderr and keep stdout available
for user errors