### PR TITLE
[HOPSWORKS-3221] Remove configuration for Spark dist file number of replicas and rely solely on HopsFS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,6 @@ default['hadoop_spark']['master']['public_key']                    = ""
 default['hadoop_spark']['yarn']['support']                         = "false"
 default['hadoop_spark']['authenticate']['secret']                  = ""
 default['hadoop_spark']['yarn']['am']['waitTime']                  = "100s"
-default['hadoop_spark']['yarn']['submit']['file']['replication']   = 3
 default['hadoop_spark']['yarn']['preserve']['staging']['files']    = "false"
 default['hadoop_spark']['yarn']['scheduler']['heartbeat']['interval_ms'] = 5000
 default['hadoop_spark']['yarn']['queue']                           = "default"

--- a/templates/default/spark-defaults.conf.erb
+++ b/templates/default/spark-defaults.conf.erb
@@ -31,7 +31,6 @@ spark.metrics.conf                <%= node['hadoop_spark']['conf_dir'] %>/metric
 <%= auth  %>
 
 spark.yarn.am.waitTime                     <%= node['hadoop_spark']['yarn']['am']['waitTime'] %>
-spark.yarn.submit.file.replication         <%= node['hadoop_spark']['yarn']['submit']['file']['replication'] %>
 spark.yarn.preserve.staging.files          <%= node['hadoop_spark']['yarn']['preserve']['staging']['files'] %>
 spark.yarn.scheduler.heartbeat.interval-ms <%= node['hadoop_spark']['yarn']['scheduler']['heartbeat']['interval_ms'] %>
 spark.yarn.queue                           <%= node['hadoop_spark']['yarn']['queue'] %>


### PR DESCRIPTION
https://hopsworks.atlassian.net/browse/HOPSWORKS-3221